### PR TITLE
Adiciona include guard

### DIFF
--- a/configChat.inc
+++ b/configChat.inc
@@ -15,6 +15,14 @@
 
 */
 
+#if defined _inc_chatc
+	#undef _inc_chatc
+#endif
+#if defined _chatc_included
+	#endinput
+#endif
+#define _chatc_included
+
 
 			// Definers
 #define			DEFAULT_CHAT_CONNECT_PLAYER			(true)


### PR DESCRIPTION
Adiciona include guard para evitar que a include seja incluída mais de uma vez no mesmo código e para que seja possível verificar se a biblioteca está sendo usada ou não.